### PR TITLE
Crime map table mobile responsive

### DIFF
--- a/app/views/crime_maps/index.html.erb
+++ b/app/views/crime_maps/index.html.erb
@@ -37,29 +37,37 @@
   Poly_map_string: <%= @poly_map_string %>
 <% end %>
 
-  <table class="table mt-3">
-    <tr>
-      <th>Crime Category</th>
-      <th>Latitude</th>
-      <th>Longitude</th>
-      <th>Location Description</th>
-      <th>Street ID</th>
-      <th>Outcome Category</th>
-    </tr>
-  <% @crime_lookups.each do |crime_lookup|%>
-    <tr>
-      <td><%= crime_lookup["category"] %></td>
-      <td><%= crime_lookup["location"]["latitude"] %></td>
-      <td><%= crime_lookup["location"]["longitude"] %></td>
-      <td><%= crime_lookup["location"]["street"]["name"] %></td>
-      <td><%= crime_lookup["location"]["street"]["id"] %></td>
-    <% if crime_lookup["outcome_status"] == nil %>
-      <td>No Outcome Added</td>
-      <% else %>
-      <td><%= crime_lookup["outcome_status"]["category"] %></td>
-      <% end %>
+<div class="table-responsive">
+  <table class="table table-striped table-bordered mt-3">
+    <thead class="table-dark">
+      <tr>
+        <th>Crime Category</th>
+        <th>Latitude</th>
+        <th>Longitude</th>
+        <th>Location Description</th>
+        <th>Street ID</th>
+        <th>Outcome Category</th>
       </tr>
-    <% end %>
+    </thead>
+
+    <tbody>
+      <% @crime_lookups.each do |crime_lookup| %>
+        <tr>
+          <td><%= crime_lookup["category"] %></td>
+          <td><%= crime_lookup["location"]["latitude"] %></td>
+          <td><%= crime_lookup["location"]["longitude"] %></td>
+          <td><%= crime_lookup["location"]["street"]["name"] %></td>
+          <td><%= crime_lookup["location"]["street"]["id"] %></td>
+          <td>
+            <% if crime_lookup["outcome_status"].nil? %>
+              No Outcome Added
+            <% else %>
+              <%= crime_lookup["outcome_status"]["category"] %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
   </table>
 </div>
 


### PR DESCRIPTION
This makes the table on the crime map mobile responsive. Unfortunately the table is a bit wide to fit on the page, so the bootstrap I added makes it responsive in the way that the table is like its own window, it will fit the screen and the user can swipe across the width of the table to view all the fields. up to you guys if you want to add.